### PR TITLE
Send class update to player when it change classes by ENABLE_SIMPLE_2…

### DIFF
--- a/AL-Game/data/scripts/system/handlers/quest/ascension/_1006Ascension.java
+++ b/AL-Game/data/scripts/system/handlers/quest/ascension/_1006Ascension.java
@@ -55,6 +55,10 @@ public class _1006Ascension extends QuestHandler {
 	
 	@Override
 	public void register() {
+		if (CustomConfig.ENABLE_SIMPLE_2NDCLASS) {
+			return;
+		}
+
 		int[] mobs = {211042, 211043};
 		int[] npcs = {790001, 730008, 205000};
 		qe.registerOnLevelUp(questId);

--- a/AL-Game/data/scripts/system/handlers/quest/ascension/_2008Ascension.java
+++ b/AL-Game/data/scripts/system/handlers/quest/ascension/_2008Ascension.java
@@ -52,6 +52,10 @@ public class _2008Ascension extends QuestHandler {
 	
 	@Override
 	public void register() {
+		if (CustomConfig.ENABLE_SIMPLE_2NDCLASS) {
+			return;
+		}
+
 		qe.registerOnLevelUp(questId);
 		qe.registerQuestNpc(203550).addOnTalkEvent(questId);
 		qe.registerQuestNpc(790003).addOnTalkEvent(questId);

--- a/AL-Game/src/com/aionemu/gameserver/services/ClassChangeService.java
+++ b/AL-Game/src/com/aionemu/gameserver/services/ClassChangeService.java
@@ -183,15 +183,19 @@ public class ClassChangeService {
 		QuestState qs = player.getQuestStateList().getQuestState(questId);
 		Calendar calendar = Calendar.getInstance();
 		Timestamp timeStamp = new Timestamp(calendar.getTime().getTime());
+
 		if (qs == null) {
 			player.getQuestStateList().addQuest(questId, new QuestState(questId, QuestStatus.COMPLETE, 0, 1, null, 0, timeStamp));
-			PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(questId, QuestStatus.COMPLETE.value(), 0));
-		} else {
-			qs.setStatus(QuestStatus.COMPLETE);
-			qs.setCompleteCount(qs.getCompleteCount() + 1);
-            player.getCommonData().setExp(126150, true); //exp give from quest 1006, 2008 
-			PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(questId, qs.getStatus(), qs.getQuestVars().getQuestVars()));
 		}
+
+		qs = player.getQuestStateList().getQuestState(questId);
+
+		qs.setStatus(QuestStatus.COMPLETE);
+		qs.setCompleteCount(qs.getCompleteCount() + 1);
+
+		player.getCommonData().setExp(126150, true); //exp give from quest 1006, 2008
+
+		PacketSendUtility.sendPacket(player, new SM_QUEST_ACTION(questId, qs.getStatus(), qs.getQuestVars().getQuestVars()));
 	}
 
 	public static void setClass(Player player, PlayerClass playerClass) {


### PR DESCRIPTION
DainAvenger - Prevent send ascension quest to player when  ENABLE_SIMPLE_2NDCLASS is activated.
DragonicK - Fix completeQuest method that is not sending updated class content to player.